### PR TITLE
Added Data Filtering for all stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/api/fetch.js
+++ b/api/fetch.js
@@ -1,37 +1,18 @@
 const axios = require("axios");
 require("dotenv").config();
 
-function request(data, headers) {
+// Github Search REST API currently does not support sorting repositories by number of stars
+const fetchTotalStars = (parameters, token) => {
   return axios({
     url: "https://api.github.com/graphql",
     method: "post",
-    headers,
-    data,
-  });
-}
-
-const graphfetch = (parameters, token) => {
-  return request(
-    {
+    headers: {
+      Authorization: `bearer ${token}`,
+    },
+    data: {
       query: `
         query userInfo($login: String!) {
           user(login: $login) {
-            name
-            login
-            contributionsCollection {
-              totalCommitContributions
-              restrictedContributionsCount
-            }
-            repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
-              totalCount
-            }
-            pullRequests(first: 1) {
-              totalCount
-            }
-            issues(first: 1) {
-              totalCount
-            }
-
             repositories(first: 100, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               totalCount
               nodes {
@@ -43,16 +24,82 @@ const graphfetch = (parameters, token) => {
           }
         }
         `,
-
       variables: parameters,
     },
-    {
-      Authorization: `bearer ${token}`,
-    }
+  }).then((e) =>
+    e.data.data.user.repositories.nodes.reduce((prev, curr) => {
+      return prev + curr.stargazers.totalCount;
+    }, 0)
   );
 };
-export async function fetchStats(username) {
-  let res = await graphfetch({ login: username }, process.env.TOKEN);
 
-  return res.data;
+// https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-commits
+const fetchTotalCommits = (variables, token) => {
+  return axios({
+    method: "get",
+    url: `https://api.github.com/search/commits?q=author:${variables.login}+committer-date:>2020-01-01`,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github.cloak-preview",
+      Authorization: `bearer ${token}`,
+    },
+  }).then((e) => e.data.total_count);
+};
+
+//https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-issues-and-pull-requests
+const fetchTotalIssues = (params, token) => {
+  return axios({
+    method: "get",
+    url: `https://api.github.com/search/issues?q=author:${params.login}+is:issue+created:2020-01-01..2020-12-31`,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github.cloak-preview",
+      Authorization: `bearer ${token}`,
+    },
+  }).then((e) => e.data.total_count);
+};
+
+//https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-issues-and-pull-requests
+const fetchTotalPRs = (params, token) => {
+  return axios({
+    method: "get",
+    url: `https://api.github.com/search/issues?q=author:${params.login}+is:pr+created:2020-01-01..2020-12-31`,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github.cloak-preview",
+      Authorization: `bearer ${token}`,
+    },
+  }).then((e) => e.data.total_count);
+};
+
+const statsFetch = async (parameters) => {
+  const _stats = {
+    pr: 0,
+    stars: 0,
+    issues: 0,
+    commits: 0,
+  };
+
+  _stats.commits = await fetcher(fetchTotalCommits, parameters);
+  _stats.issues = await fetcher(fetchTotalIssues, parameters);
+  _stats.pr = await fetcher(fetchTotalPRs, parameters);
+  _stats.stars = await fetcher(fetchTotalStars, parameters);
+
+  return _stats;
+};
+
+// Resolves the relevant function with tokens
+const fetcher = async (func, params) => {
+  try {
+    let res = await func(params, process.env.TOKEN);
+    return res;
+  } catch (e) {
+    console.log(e);
+    return 0;
+  }
+};
+
+export async function fetchStats(username) {
+  let res = await statsFetch({ login: username });
+  return res;
 }

--- a/api/index.js
+++ b/api/index.js
@@ -2,38 +2,15 @@ const { fetchStats } = require("./fetch");
 
 module.exports = async (req, res) => {
   const { username } = req.query;
-  let stats = {
-    name: "",
-    commits: 0,
-    stars: 0,
-    pr: 0,
-    issues: 0,
-  };
 
   res.setHeader("Content-Type", "application/json");
 
   try {
     const _call = await fetchStats(username);
-    res.setHeader("Cache-Control", `public, max-age=86400`);
-
-    let _currentuser = _call.data.user;
-
-    stats.name = _currentuser.name || _currentuser.login;
-
-    stats.issues = _currentuser.issues.totalCount;
-
-    stats.commits =
-      _currentuser.contributionsCollection.totalCommitContributions;
-
-    stats.pr = _currentuser.pullRequests.totalCount;
-
-    // Traverse through all the nodes to get the sum
-    stats.stars = _currentuser.repositories.nodes.reduce((prev, curr) => {
-      return prev + curr.stargazers.totalCount;
-    }, 0);
+    res.setHeader("Cache-Control", `public, max-age=1800`);
 
     return res.send({
-      data: { ...stats },
+      data: { ..._call },
       generated_at: new Date().getTime(),
       error_code: 0,
     });


### PR DESCRIPTION
## Changes

* Due to some limitations of  github's graphql api's sorting and other potential parameters, we weren't able to filter the results to the year 2020
* Instead of relying on graphql api, the requests are split up into 3 rest api requests, with filters for date starting from 1st Jan 2020
* Although, this would increase the number of requests we have to make per user, but we can overcome that using a multi token system to increase the rate limits

### Potential Fix for #7 