### PR TITLE
MultiTokenizer + Yearly Stats

### DIFF
--- a/api/fetch.js
+++ b/api/fetch.js
@@ -1,37 +1,20 @@
 const axios = require("axios");
 require("dotenv").config();
 
-function request(data, headers) {
+const { multiTokenizer } = require("./multitokenizer");
+
+// Github Search REST API currently does not support sorting repositories by number of stars
+const fetchTotalStars = (parameters, token) => {
   return axios({
     url: "https://api.github.com/graphql",
     method: "post",
-    headers,
-    data,
-  });
-}
-
-const graphfetch = (parameters, token) => {
-  return request(
-    {
+    headers: {
+      Authorization: `bearer ${token}`,
+    },
+    data: {
       query: `
         query userInfo($login: String!) {
           user(login: $login) {
-            name
-            login
-            contributionsCollection {
-              totalCommitContributions
-              restrictedContributionsCount
-            }
-            repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
-              totalCount
-            }
-            pullRequests(first: 1) {
-              totalCount
-            }
-            issues(first: 1) {
-              totalCount
-            }
-
             repositories(first: 100, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
               totalCount
               nodes {
@@ -43,16 +26,83 @@ const graphfetch = (parameters, token) => {
           }
         }
         `,
-
       variables: parameters,
     },
-    {
-      Authorization: `bearer ${token}`,
-    }
+  }).then((e) =>
+    e.data.data.user.repositories.nodes.reduce((prev, curr) => {
+      return prev + curr.stargazers.totalCount;
+    }, 0)
   );
 };
-export async function fetchStats(username) {
-  let res = await graphfetch({ login: username }, process.env.TOKEN);
 
-  return res.data;
+// https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-commits
+const fetchTotalCommits = (variables, token) => {
+  return axios({
+    method: "get",
+    url: `https://api.github.com/search/commits?q=author:${variables.login}+committer-date:>2020-01-01`,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github.cloak-preview",
+      Authorization: `bearer ${token}`,
+    },
+  }).then((e) => e);
+};
+
+//https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-issues-and-pull-requests
+const fetchTotalIssues = (params, token) => {
+  return axios({
+    method: "get",
+    url: `https://api.github.com/search/issues?q=author:${params.login}+is:issue+created:2020-01-01..2020-12-31`,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github.cloak-preview",
+      Authorization: `bearer ${token}`,
+    },
+  }).then((e) => e);
+};
+
+//https://docs.github.com/en/free-pro-team@latest/rest/reference/search#search-issues-and-pull-requests
+const fetchTotalPRs = (params, token) => {
+  return axios({
+    method: "get",
+    url: `https://api.github.com/search/issues?q=author:${params.login}+is:pr+created:2020-01-01..2020-12-31`,
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/vnd.github.cloak-preview",
+      Authorization: `bearer ${token}`,
+    },
+  }).then((e) => e);
+};
+
+const statsFetch = async (parameters) => {
+  const _stats = {
+    pr: 0,
+    stars: 0,
+    issues: 0,
+    commits: 0,
+  };
+
+  _stats.commits = await fetcher(fetchTotalCommits, parameters);
+  _stats.issues = await fetcher(fetchTotalIssues, parameters);
+  _stats.pr = await fetcher(fetchTotalPRs, parameters);
+  _stats.stars = await fetchTotalStars(parameters, process.env.TOKEN_1);
+
+  return _stats;
+};
+
+const fetcher = async (func, params) => {
+  try {
+    // let res = await func(params, process.env.TOKEN_1);
+    // return res;
+    let res = await multiTokenizer(func, params, 0);
+    return res;
+  } catch (e) {
+    console.log(e);
+    return 0;
+  }
+};
+
+export async function fetchStats(username) {
+  let res = await statsFetch({ login: username });
+  return res;
 }

--- a/api/index.js
+++ b/api/index.js
@@ -14,26 +14,10 @@ module.exports = async (req, res) => {
 
   try {
     const _call = await fetchStats(username);
-    res.setHeader("Cache-Control", `public, max-age=86400`);
-
-    let _currentuser = _call.data.user;
-
-    stats.name = _currentuser.name || _currentuser.login;
-
-    stats.issues = _currentuser.issues.totalCount;
-
-    stats.commits =
-      _currentuser.contributionsCollection.totalCommitContributions;
-
-    stats.pr = _currentuser.pullRequests.totalCount;
-
-    // Traverse through all the nodes to get the sum
-    stats.stars = _currentuser.repositories.nodes.reduce((prev, curr) => {
-      return prev + curr.stargazers.totalCount;
-    }, 0);
+    res.setHeader("Cache-Control", `public, max-age=1800`);
 
     return res.send({
-      data: { ...stats },
+      data: { ..._call },
       generated_at: new Date().getTime(),
       error_code: 0,
     });

--- a/api/multitokenizer.js
+++ b/api/multitokenizer.js
@@ -1,0 +1,17 @@
+require("dotenv").config();
+
+export const multiTokenizer = async (func, params, token_no) => {
+  try {
+    let res = await func(params, process.env[`TOKEN_${token_no + 1}`]);
+
+    return res.data.total_count;
+  } catch (e) {
+    if (token_no < process.env.TOKENS_COUNT) {
+      // If there is an error, try with other tokens
+      return multiTokenizer(func, params, token_no + 1);
+    }
+
+    // If exceeds the number of tokens, return 0 so that app does not crash
+    return 0;
+  }
+};

--- a/src/components/landing-header/index.jsx
+++ b/src/components/landing-header/index.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 export default function LandingHeader({
-  inputHandler,
-  keyUpHandler,
-  username,
+    inputHandler,
+    keyUpHandler,
+    username
 }) {
   return (
     <>
@@ -17,12 +17,10 @@ export default function LandingHeader({
       <p className="landing__p2">
         Let's take a look back at all the contributions
         <span className="highlight"> you</span> as an individual
-        <br /> made to the open-source community, during these unprecedented
-        times.
+        <br />
+        made to the open-source community, during these unprecedented times.
       </p>
-      <span className="disclaimer">
-        *This project is neither maintained nor endorsed by GitHub
-      </span>
+
       <input
         className="landing__input"
         type="text"

--- a/src/containers/landing/style.scss
+++ b/src/containers/landing/style.scss
@@ -41,15 +41,10 @@
         font-size: 0.9rem;
       }
     }
-    .disclaimer {
-      font-weight: 500;
-      margin-top: 0.5rem;
-    }
+
     .landing__p2 {
       font-weight: 300;
       margin: 0.5rem 0;
-
-    
 
       @media screen and (max-width: 720px) {
         font-size: 0.9rem;
@@ -76,6 +71,10 @@
 
       display: block;
       width: 50%;
+
+      @media screen and (max-height: 720px) {
+        width: 40%;
+      }
 
       @media screen and (max-width: 480px) {
         width: 75%;


### PR DESCRIPTION
* The current rest API Implementation has limitation for upto 30 requests/minute, and based on the site traffic, it'd become bottleneck issue. This PR addresses this issue

## Changes
* Added Multi-tokenizer which would kick in, in case one personal access token fails
* Date-filtering is again added to only show stats for 2020 as a replacement for #8 

Should fix #11 and #7